### PR TITLE
김은진: 화상채팅 기본 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+front/yarn.lock

--- a/app.js
+++ b/app.js
@@ -106,7 +106,7 @@ io.on("connection", (socket) => {
 
     // 로그인 결과를 client에게 전송
     // socket.emit("login-result",resultData)
-    // resultData = {result: true/false, msg, rooms}
+    // resultData = {result: true/false, msg, rooms,nickname,img}
 
     if (result) {
       // 로그인 성공
@@ -121,10 +121,13 @@ io.on("connection", (socket) => {
       console.log(
         `login success, socketID: ${socket.id}, nickname: ${socket.nickname}`
       );
+      socket.emit("login-result",resultData) 
     } else {
       // 로그인 실패
+      resultData.result = false;
       resultData.msg = "Please enter new nickname";
       console.log("login Fail");
+      socket.emit("login-result",resultData)
     }
   });
 

--- a/public/BackEnd/index.html
+++ b/public/BackEnd/index.html
@@ -67,6 +67,10 @@
         <ul id="memList"></ul>
       </div>
 
+      <div id="videoChatArea">
+
+      </div>
+
       <ul id="messages"></ul>
       <form id="messageForm" action="">
         <input id="messageInput" autocomplete="off" /><button>Send</button>
@@ -77,7 +81,12 @@
 <script>
   var socket = io();
   var currentArea='login'
+  var jitsiApi // 화상채팅 jitsi API 전역변수로 설정
+  var loginInfo // client단에서 자신의 nickname과 img 접근하게 하기위함
 </script>
+
+<script src='https://meet.jit.si/external_api.js'></script>
+
 <script src="./js/login.js"></script>
 <script src="./js/lobby.js"></script>
 <script src="./js/chat.js"></script>

--- a/public/BackEnd/js/chat.js
+++ b/public/BackEnd/js/chat.js
@@ -115,7 +115,11 @@ socket.on('notify-message', function(msg) {
 function clickRoomOut(){
   var input=confirm("want to leave this room?");
   if(input){
-    socket.emit("room-out")
+    socket.emit("room-out");
+
+    // 화상채팅 자동 종료 및 html clear
+    jitsiApi.executeCommand('hangup');
+    document.getElementById('videoChatArea').innerHTML=""
 
     document.getElementById('chatArea').className="d-none"
     document.getElementById('lobbyArea').className=""

--- a/public/BackEnd/js/lobby.js
+++ b/public/BackEnd/js/lobby.js
@@ -74,6 +74,27 @@ socket.on('room-create-result',(data)=>{
 function room_in(roomname){
   document.getElementById('lobbyArea').className="d-none"
   document.getElementById('chatArea').className=""
+
+  // jitsi 화상채팅 api 호출
+  const domain = 'meet.jit.si';
+  const options = {
+    roomName: roomname,
+    width: 700,
+    height: 700,
+    parentNode: document.querySelector('#videoChatArea'), // html 화상채팅 영역 
+    userInfo:{
+      email:loginInfo.nickname+"@gmail.com",
+      displayName:loginInfo.nickname // client가 가지고 있는 nickname 자동으로 넘겨주기
+    },
+    configOverwrite:{prejoinConfig: {enabled:false}} // 화상채팅방 참여 대기 페이지 skip하고 바로 화상채팅방에 참여시키기
+  };
+
+  jitsiApi= new JitsiMeetExternalAPI(domain, options);
+
+  // client의 avatar img 넘겨주기 -> 해당 client가 선택한 img url 필요함. url 어케 넘겨줄건지 결정해서 수정해주세요!!
+  jitsiApi.executeCommand('avatarUrl', 'http://localhost:3383/BackEnd/images/01.png')
+
+  
   socket.emit("room-in",roomname)
   currentArea='chat'
 }

--- a/public/BackEnd/js/login.js
+++ b/public/BackEnd/js/login.js
@@ -52,7 +52,7 @@ loginForm.addEventListener('submit', function(e) {
 
 // 서버로부터 로그인 결과 받음 -> "login-result"를 listen하고 lobbyArea 보여주기 및 currentArea 변경
 // socket.emit("login-result",data)에 대한 listener
-// data = {result: true/false, msg, rooms}
+// data = {result: true/false, msg, rooms,nickname,img}
 socket.on('login-result',(data)=>{
   if(!data.result) //로그인 실패
     alert(data.msg);
@@ -62,6 +62,8 @@ socket.on('login-result',(data)=>{
     document.getElementById('loginArea').className="d-none"
     document.getElementById('lobbyArea').className=""
     currentArea="lobby"
+
+    loginInfo=data // client단에서 자신의 nickname과 img 접근하게 하기위함
 
     // lobby의 active한 room list update
     lobby_roomUpdate(data.rooms)


### PR DESCRIPTION
<구현된 부분>
채팅방 입장 시 화상채팅 자동 시작(client의 nickname과 avatar img 자동으로 넘겨줌)
채팅방 퇴장 시 화상채팅 자동 종료
(app.js에서 터미널에 node app.js 입력 후 http://localhost:3383/BackEnd/ 로 접속 가능)


<추가 구현해야될 부분>
 jitsi api에서는 roomname이 앞글자가 자동으로 대문자처리됨( jitsi에서 이름이 Room인 방과 room인 방을 동일한 방으로 취급함) 
=> client로부터 roomname 입력받은 후 app.js 서버에서 roomname string을 대문자로 바꿔서 중복체크해야됨 (Room과 room은 동일 방 처리하고 방 아예 생성되지 않도록해야함)

client가 선택한 avatar의 url을 jitsi api에 전달해야함

화상채팅 area 내부의 화상통화종료 버튼 없애야함 (방 나가기를 눌러야만 채팅 종료할 수 있도록)